### PR TITLE
7장 컴포넌트의 라이프사이클 메서드

### DIFF
--- a/hello-practice-react/src/LifeCycleSample/App.js
+++ b/hello-practice-react/src/LifeCycleSample/App.js
@@ -1,0 +1,31 @@
+import { Component } from "react";
+import LifeCycleSample from "./LifeCycleSample";
+import ErrorBoundary from "./ErrorBoundary";
+
+function getRandomColor() {
+  return "#" + Math.floor(Math.random() * 16777215).toString(16);
+}
+
+class App extends Component {
+  state = {
+    color: "#000000",
+  };
+
+  handleClick = () => {
+    this.setState({
+      color: getRandomColor(),
+    });
+  };
+  render() {
+    return (
+      <div>
+        <button onClick={this.handleClick}>랜덤 색상</button>
+        <ErrorBoundary>
+          <LifeCycleSample color={this.state.color} />
+        </ErrorBoundary>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/hello-practice-react/src/LifeCycleSample/ErrorBoundary.js
+++ b/hello-practice-react/src/LifeCycleSample/ErrorBoundary.js
@@ -1,0 +1,21 @@
+import { Component } from "react";
+
+class ErrorBoundary extends Component {
+  state = {
+    error: false,
+  };
+
+  componentDidCatch(error, info) {
+    this.setState({
+      error: true,
+    });
+    console.log({ error, info });
+  }
+
+  render() {
+    if (this.state.error) return <div>에러가 발생했습니다</div>;
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/hello-practice-react/src/LifeCycleSample/LifeCycleSample.js
+++ b/hello-practice-react/src/LifeCycleSample/LifeCycleSample.js
@@ -1,0 +1,78 @@
+import { Component } from "react";
+
+class LifeCycleSample extends Component {
+  state = {
+    number: 0,
+    color: null,
+  };
+
+  myRef = null;
+
+  constructor(props) {
+    super(props);
+    console.log("constructor");
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    console.log("getDerivedStateFromProps");
+    if (nextProps.color !== prevState.color) {
+      return { color: nextProps.color };
+    }
+    return null;
+  }
+
+  componentDidMount() {
+    console.log("componentDidMount");
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    console.log("shouldComponentUpdaate", nextProps, nextState);
+    return nextState.number % 10 !== 4;
+  }
+
+  componentWillUnmount() {
+    console.log("componentWillUnmount");
+  }
+
+  handleClick = () => {
+    this.setState({
+      number: this.state.number + 1,
+    });
+  };
+
+  getSnapshotBeforeUpdate(prevProps, prevState) {
+    console.log("getSnapshotBeForeUpdate");
+    if (prevProps.color !== this.props.color) {
+      return this.myRef.style.color;
+    }
+    return null;
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    console.log("componentDidUpDate", prevProps, prevState);
+    if (snapshot) {
+      console.log("업데이트되기 직전 색상", snapshot);
+    }
+  }
+
+  render() {
+    console.log("render");
+
+    const style = {
+      color: this.props.color,
+    };
+
+    return (
+      <div>
+        {this.props.missing.value}
+        <h1 style={style} ref={(ref) => (this.myRef = ref)}>
+          {this.state.number}
+        </h1>
+        <p>color: {this.state.color}</p>
+        <button onClick={this.handleClick}>더하기</button>
+      </div>
+    );
+  }
+}
+
+export default LifeCycleSample;

--- a/hello-practice-react/src/Router.js
+++ b/hello-practice-react/src/Router.js
@@ -4,6 +4,7 @@ import Event from "./EventHandle/App";
 import App from "./App";
 import DOM from "./DOM/App";
 import IterationSample from "./RepeatComponents/App";
+import LifeCycleSample from "./LifeCycleSample/App";
 
 function Router() {
   return (
@@ -13,6 +14,7 @@ function Router() {
         <Route path="/Event" element={<Event />} />
         <Route path="/DOM" element={<DOM />} />
         <Route path="/IterationSample" element={<IterationSample />} />
+        <Route path="/LifeCycleSample" element={<LifeCycleSample />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
##7장 컴포넌트의 라이프사이클 메서드

### 라이프사이클 메서드 살펴보기

- constructor 메서드 : 컴포넌트를 새로 만들 때마다 호출되는 클래스 생성자 메서드
- getDerivedStateFromProps : props에 있는 값을 state에 넣을 때 사용하는 메서드
- render : UI를 렌더링하는 메서드
- componentDidMount : 컴포넌트가 웹 브라우저상에 나타난 후 호출하는 메서드 (컴포넌트를 만들고, 첫 렌더링을 다 마친 후 실행한다)
- shouldComponentUpdate : props 또는 state를 변경했을 때, 리렌더링을 시작할지 여부를 지정하는 메서드 (반드시 true/false값을 반환)
- getSnapshotBeforeUpdate : render에서 만들어진 결과물이 브라우저에 실제로 반영되기 직전에 호출 (ex. 스크롤바 위치 유지)
- componentDidUpdate : 리렌더링을 완료한 후 실행한다
- componentWillUnmount : 컴포넌트를 DOM에서 제거할 때 실행
- componentDidCatch : 컴포넌트 렌더링 도중에 에러가 발생했을 때 애플리케이션이 먹통이 되지 않고 오류 UI를 보여줄수 있게 한다.


**업데이트**
>컴포넌트의 업데이트 경우

1. props가 바뀔 때
2. state가 바뀔 때
3. 부모 컴포넌트가 리렌더링될 때
4. this.forceUpdate로 강제로 렌더링을 트리거할 때